### PR TITLE
Adjust card margins for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,11 @@
       padding: 20px;
       border-radius: 20px;
       box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
-      width: 350px;
+      box-sizing: border-box;
+      /* Add extra breathing room for mobile screens */
+      width: calc(100% - 60px);
+      max-width: 350px;
+      margin: 30px;
       text-align: center;
     }
 

--- a/log_graph_page.html
+++ b/log_graph_page.html
@@ -23,10 +23,11 @@
       padding: 20px;
       border-radius: 20px;
       box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
-      width: 90%;
+      box-sizing: border-box;
+      /* Add extra breathing room for mobile screens */
+      width: calc(100% - 60px);
       max-width: 600px;
-      margin-top: 20px;
-      margin-bottom: 20px;
+      margin: 30px auto;
     }
 
     h1 {

--- a/settings_page.html
+++ b/settings_page.html
@@ -23,7 +23,11 @@
       padding: 20px;
       border-radius: 20px;
       box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
-      width: 400px;
+      box-sizing: border-box;
+      /* Add extra breathing room for mobile screens */
+      width: calc(100% - 60px);
+      max-width: 400px;
+      margin: 30px;
       text-align: center;
     }
 


### PR DESCRIPTION
## Summary
- tweak margins on index, settings, and log pages so cards don't touch the edges on smaller screens

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5ed8b8e083319cbb42e328981360