### PR TITLE
Fix graph point order and chart sizing

### DIFF
--- a/log_graph_page.html
+++ b/log_graph_page.html
@@ -69,6 +69,12 @@
     .back-link:hover {
       color: #2575fc;
     }
+
+    /* Ensure the chart canvas fills its container */
+    #logChart {
+      width: 100%;
+      height: 300px;
+    }
   </style>
 </head>
 <body>
@@ -125,13 +131,17 @@
         '#ff6384', '#36a2eb', '#cc65fe', '#ffce56', '#2ecc71', '#e74c3c'
       ];
 
-      const datasets = Object.entries(grouped).map(([date, points], idx) => ({
-        label: date,
-        data: points,
-        borderColor: colors[idx % colors.length],
-        fill: false,
-        tension: 0.2
-      }));
+      const datasets = Object.entries(grouped).map(([date, points], idx) => {
+        // Sort points by hour to ensure lines connect in order
+        points.sort((a, b) => a.x - b.x);
+        return {
+          label: date,
+          data: points,
+          borderColor: colors[idx % colors.length],
+          fill: false,
+          tension: 0.2
+        };
+      });
 
       const ctx = document.getElementById('logChart').getContext('2d');
       new Chart(ctx, {


### PR DESCRIPTION
## Summary
- sort data points before creating chart datasets
- size the log chart canvas so it's visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c436374308331a2d7737663101f8e