### PR TITLE
Fix service worker Chart.js caching

### DIFF
--- a/log_graph_page.html
+++ b/log_graph_page.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Log History</title>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" crossorigin="anonymous"></script>
   <style>
     body {
       font-family: Arial, sans-serif;

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,18 +1,17 @@
-self.addEventListener("install", (event) => {
+self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open("bolus-calculator-v1").then((cache) => {
-      return cache.addAll([
-        "./",
-        "./index.html",
-        "./settings_page.html",
-        "./log_graph_page.html",
-        "./manifest.json",
-        "./icon-192.png",
-        "./icon-512.png",
-        "./timeUtils.js",
-        "https://cdn.jsdelivr.net/npm/chart.js"
-      ]);
-    })
+    caches.open('bolus-calculator-v2').then(cache =>
+      cache.addAll([
+        './',
+        './index.html',
+        './settings_page.html',
+        './log_graph_page.html',
+        './manifest.json',
+        './icon-192.png',
+        './icon-512.png',
+        './timeUtils.js'
+      ])
+    )
   );
 });
 


### PR DESCRIPTION
## Summary
- avoid pre-caching Chart.js
- load Chart.js from CDN at runtime with CORS
- bump service worker cache name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c47905b488331a29e4441c2246310