### PR TITLE
Hide navigation when no log data

### DIFF
--- a/log_graph_page.html
+++ b/log_graph_page.html
@@ -157,6 +157,13 @@
 
       const ctx = document.getElementById('logChart').getContext('2d');
       const dateLabel = document.getElementById('currentDate');
+      const prevBtn = document.getElementById('prevDay');
+      const nextBtn = document.getElementById('nextDay');
+
+      if (dates.length === 0) {
+        prevBtn.style.display = 'none';
+        nextBtn.style.display = 'none';
+      }
 
       let chart;
       function renderChart() {
@@ -251,18 +258,20 @@
         });
       }
 
-      document.getElementById('prevDay').addEventListener('click', () => {
-        if (currentIndex > 0) {
-          currentIndex--;
-          renderChart();
-        }
-      });
-      document.getElementById('nextDay').addEventListener('click', () => {
-        if (currentIndex < dates.length - 1) {
-          currentIndex++;
-          renderChart();
-        }
-      });
+      if (dates.length > 0) {
+        prevBtn.addEventListener('click', () => {
+          if (currentIndex > 0) {
+            currentIndex--;
+            renderChart();
+          }
+        });
+        nextBtn.addEventListener('click', () => {
+          if (currentIndex < dates.length - 1) {
+            currentIndex++;
+            renderChart();
+          }
+        });
+      }
 
       renderChart();
     });


### PR DESCRIPTION
## Summary
- hide Previous/Next day buttons when there are no grouped dates
- attach navigation handlers only if dates are present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c4798ff44833183d50febec4bb246